### PR TITLE
1.6.1.3: OpusDecoder native library load-order fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.6.1.3
+
+### Fixed
+- Fix `OpusDecoder` failing to initialize when it is the first Kopus object created in a process — `nativeCreate()` was called before the native library was loaded ([#8](https://github.com/yankeppey/kopus/pull/8))
+
 ## 1.6.1.2
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Kopus is a lightweight Kotlin Multiplatform wrapper for the [Opus audio codec](h
 ```kotlin
 dependencies {
     // Standard version
-    implementation("eu.buney.kopus:kopus:1.6.1.2")
+    implementation("eu.buney.kopus:kopus:1.6.1.3")
 
     // Full version with DRED/OSCE/QEXT (larger binary size)
-    implementation("eu.buney.kopus:kopus-full:1.6.1.2")
+    implementation("eu.buney.kopus:kopus-full:1.6.1.3")
 }
 ```
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.0.1"
 composeCharts = "0.2.5"
-kopus = "1.6.1.2"
+kopus = "1.6.1.3"
 kotlin = "2.3.10"
 android-compileSdk = "36"
 android-minSdk = "26"


### PR DESCRIPTION
## Summary
- Fix `OpusDecoder` failing to initialize when it is the first Kopus object created in a process — `nativeCreate()` was called before the native library was loaded (#8)
- Restore the Android native build on the macOS 26 CI runners and bump GitHub Actions to Node 24 runtimes (#9)